### PR TITLE
Bug fix: Save unedited images for calibration

### DIFF
--- a/capture_calibration_images.py
+++ b/capture_calibration_images.py
@@ -77,7 +77,7 @@ def capture_calibration_images():
         elif key == ord('c') and ret_chess:
             # Save the image if a chess board is detected
             img_name = os.path.join(OUTPUT_DIRECTORY, f"calibration_{img_counter:02d}.png")
-            cv2.imwrite(, orig_frame)
+            cv2.imwrite(img_name, orig_frame)
             print(f"Captured {img_name}")
             
             img_counter += 1

--- a/capture_calibration_images.py
+++ b/capture_calibration_images.py
@@ -32,14 +32,15 @@ def capture_calibration_images():
     # Counter for captured images
     img_counter = 0
     
-    print("Press 'c' to capture an image")
+    print("Press 'c' to capture an image if a chess board is detected")
     print("Press 'q' or Escape to quit")
     print(f"Images will be saved to {OUTPUT_DIRECTORY}")
     
     while True:
         # Capture frame
-        ret, frame = cap.read()
-        
+        ret, orig_frame = cap.read()
+        # Make a copy of the frame we can modify and display
+        frame = orig_frame.copy()
         if not ret:
             print("Error: Failed to capture image")
             break
@@ -73,10 +74,10 @@ def capture_calibration_images():
             break
         
         # 'c' to capture
-        elif key == ord('c'):
-            # Save the image
-            img_name = os.path.join(OUTPUT_DIRECTORY, f"calibration_{img_counter:02d}.jpg")
-            cv2.imwrite(img_name, frame)
+        elif key == ord('c') and ret_chess:
+            # Save the image if a chess board is detected
+            img_name = os.path.join(OUTPUT_DIRECTORY, f"calibration_{img_counter:02d}.png")
+            cv2.imwrite(, orig_frame)
             print(f"Captured {img_name}")
             
             img_counter += 1


### PR DESCRIPTION
The original `capture_calibration_images.py` script annotates the frame with text and `drawChessboardCorners` before saving it for the camera calibration. This means the `camera_calibration.py` will try to detect the checkerboard in an annotated image, which may fail.

Changes:
- Save an unannotated frames for calibration instead
- Only save images if a checkerboard is successfully detected so it useful for calibration
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Modify `capture_calibration_images.py` to save unannotated frames only when a chessboard is detected for calibration.
> 
>   - **Behavior**:
>     - Modify `capture_calibration_images()` in `capture_calibration_images.py` to save unannotated frames for calibration.
>     - Only save images if a chessboard is successfully detected, ensuring useful images for calibration.
>   - **User Instructions**:
>     - Update prompt to "Press 'c' to capture an image if a chess board is detected".
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=niconielsen32%2Fcamera-calibration&utm_source=github&utm_medium=referral)<sup> for b732eee10d5f9374b67b2a99749d707f4d9876f3. You can [customize](https://app.ellipsis.dev/niconielsen32/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->