### PR TITLE
Add script for making checkerboard

### DIFF
--- a/make_checkerboard_image.py
+++ b/make_checkerboard_image.py
@@ -1,0 +1,39 @@
+import numpy as np
+import cv2
+
+SQUARE_CM = 1  # Square size in cm
+MIN_BORDER_CM = 0.1 # min_border size in cm. OpenCV requires the checkerboard to have a white border.
+SCREEN_SIZE_CM = np.array([13,6]) # Screen height and width in cm
+SCREEN_PPI = 385 # Points-per-inch resolution of the screen. Google "<device model> PPI" to find this.
+CHECKERBOARD_PATH = 'checkerboard.png'  # Path to calibration images
+
+INCHES_TO_CM = 2.54
+
+if __name__ == "__main__":
+    # Make blank white image
+    px_per_cm = int(SCREEN_PPI / INCHES_TO_CM)
+    
+    image_squares = np.floor((SCREEN_SIZE_CM - MIN_BORDER_CM * 2) / SQUARE_CM).astype(int)
+    
+    border_cm = (SCREEN_SIZE_CM - image_squares * SQUARE_CM) / 2
+    border_px = border_cm * px_per_cm
+    square_px = SQUARE_CM * px_per_cm
+
+    image = np.ones(SCREEN_SIZE_CM * px_per_cm) * 255 
+    # Calculate the square size in pixels
+    for row in range(0, image_squares[0]):
+        first_black_square = 0
+        if row % 2 == 1:
+            first_black_square = 1
+    
+        for col in range(first_black_square, image_squares[1], 2):
+            top_left = (np.array([col, row]) * square_px + border_px).astype(int)
+            bottom_right = (top_left + square_px)
+            image = cv2.rectangle(image, top_left, bottom_right.astype(int), (0,0,0), -1)
+
+    cv2.imwrite(CHECKERBOARD_PATH, image)
+
+    inner_corners = image_squares - 1
+    print(f"Checkerboard saved to {CHECKERBOARD_PATH}")
+    print(f"Inner corners: {inner_corners[0]}x{inner_corners[1]}")
+


### PR DESCRIPTION
Running the script creates a checkerboard OpenCV can detect for any phone/tablet you may have.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `make_checkerboard_image.py` to generate a checkerboard image for calibration using OpenCV.
> 
>   - **New Script**:
>     - Adds `make_checkerboard_image.py` to generate a checkerboard image for calibration.
>     - Calculates square and border sizes based on `SCREEN_SIZE_CM`, `SQUARE_CM`, and `SCREEN_PPI`.
>     - Uses OpenCV to draw the checkerboard pattern and save it to `checkerboard.png`.
>   - **Output**:
>     - Prints the path to the saved checkerboard image and the number of inner corners.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=niconielsen32%2Fcamera-calibration&utm_source=github&utm_medium=referral)<sup> for a80268422ed444cdc072e16e6ec05f38b051edf9. You can [customize](https://app.ellipsis.dev/niconielsen32/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->